### PR TITLE
Add PSM support for collateral that is not priced at $1

### DIFF
--- a/src/psm.sol
+++ b/src/psm.sol
@@ -60,7 +60,7 @@ contract Psm {
 
     int256  public tin;      // toll in  [wad]
     int256  public tout;     // toll out [wad]
-    uint256 public buff;     // A buffer which limits minting within the line
+    uint256 public buff;     // A buffer which limits minting within the line [rad]
     address public vow;
 
     bytes32     immutable public ilk;
@@ -168,7 +168,7 @@ contract Psm {
         // Transfer in gems and mint dai
         (uint256 Art,,, uint256 line,) = vat.ilks(ilk);
         require(gem.transferFrom(msg.sender, address(this), gemAmt), "Psm/failed-transfer");
-        require(Art + mintAmount + buff <= line, "Psm/buffer-exceeded");
+        require((Art + mintAmount) * RAY + buff <= line, "Psm/buffer-exceeded");
         vat.slip(ilk, address(this), _int256(gemAmt18));
         vat.frob(ilk, address(this), address(this), address(this), int256(gemAmt18), _int256(mintAmount));
 

--- a/src/tests/Psm-integration.t.sol
+++ b/src/tests/Psm-integration.t.sol
@@ -41,7 +41,7 @@ contract PsmIntegrationTest is DSSTest {
     function postSetup() internal virtual override {
         usdc = DSTokenAbstract(mcd.chainlog().getAddress("USDC"));
 
-        psm = new Psm(ILK, address(usdc), address(mcd.daiJoin()));
+        psm = new Psm(ILK, address(usdc), address(mcd.daiJoin()), address(mcd.spotter()));
         psm.file("vow", address(mcd.vow()));
 
         mcd.giveAdminAccess();

--- a/src/tests/Psm-unit.t.sol
+++ b/src/tests/Psm-unit.t.sol
@@ -108,21 +108,22 @@ contract PsmUnitTest is DSSTest {
         checkAuth(address(psm), "Psm");
     }
 
-    function testFileVow() public {
+    function testFile() public {
         checkFileAddress(address(psm), "Psm", ["vow"]);
+        checkFileUint(address(psm), "Psm", ["buff"]);
     }
 
     function testFileTolls() public {
         assertEq(psm.tin(), 0);
         vm.expectEmit(true, false, false, true);
         emit File("tin", int256(123));
-        psm.file("tin", 123);
+        psm.file("tin", int256(123));
         assertEq(psm.tin(), 123);
 
         assertEq(psm.tout(), 0);
         vm.expectEmit(true, false, false, true);
         emit File("tout", int256(123));
-        psm.file("tout", 123);
+        psm.file("tout", int256(123));
         assertEq(psm.tout(), 123);
 
         int256 SWAD = int256(WAD);
@@ -145,7 +146,7 @@ contract PsmUnitTest is DSSTest {
         psm.file("tout", -SWAD - 1);
 
         vm.expectRevert("Psm/file-unrecognized-param");
-        psm.file("bad value", 123);
+        psm.file("bad value", int256(123));
     }
 
     function testSellGemNoFee() public {
@@ -318,7 +319,7 @@ contract PsmUnitTest is DSSTest {
     }
 
     function testSwapBothOtherSmallFee() public {
-        psm.file("tin", 1);
+        psm.file("tin", int256(1));
 
         User user1 = new User(psm);
         gem.transfer(address(user1), 40 * ONE_USDX);
@@ -348,7 +349,7 @@ contract PsmUnitTest is DSSTest {
     }
 
     function testSwapBothSmallFeeInsufficientDai() public {
-        psm.file("tin", 1);        // Very small fee pushes you over the edge
+        psm.file("tin", int256(1));        // Very small fee pushes you over the edge
 
         User user1 = new User(psm);
         gem.transfer(address(user1), 40 * ONE_USDX);

--- a/src/tests/Psm-unit.t.sol
+++ b/src/tests/Psm-unit.t.sol
@@ -361,7 +361,7 @@ contract PsmUnitTest is DSSTest {
     function testSellGemOverLine() public {
         gem.mint(address(this), 1000 * ONE_USDX);
         gem.approve(address(psm), type(uint256).max);
-        vm.expectRevert("Vat/ceiling-exceeded");
+        vm.expectRevert("Psm/buffer-exceeded");     // Will trigger both buffer and DC limits
         psm.sellGem(address(this), 2000 * ONE_USDX);
     }
 
@@ -381,6 +381,16 @@ contract PsmUnitTest is DSSTest {
         psm.sellGem(address(this), 0);
         dai.approve(address(psm), type(uint256).max);
         psm.buyGem(address(this), 0);
+    }
+
+    function testBufferHit() public {
+        // Should only be able to mint to 800
+        psm.file("buff", 200 * RAD);
+
+        gem.mint(address(this), 1000 * ONE_USDX);
+        gem.approve(address(psm), type(uint256).max);
+        vm.expectRevert("Psm/buffer-exceeded");
+        psm.sellGem(address(this), 450 * ONE_USDX); // Should attempt to mint 900 DAI (over the limit)
     }
 
     function testExit() public {

--- a/src/tests/Psm-unit.t.sol
+++ b/src/tests/Psm-unit.t.sol
@@ -81,7 +81,7 @@ contract PsmUnitTest is DSSTest {
         daiJoin = new DaiJoinMock(address(vat), address(dai));
         vow = address(123);
         pip = new DSValue();
-        pip.poke(bytes32(WAD));    // $1
+        pip.poke(bytes32(2 * WAD));    // $2 for easy math
         spotter.setPip(ILK, address(pip));
         gem = new TokenMock();
         gem.mint(address(this), 1000 * ONE_USDX);
@@ -158,20 +158,20 @@ contract PsmUnitTest is DSSTest {
 
         gem.approve(address(psm), type(uint256).max);
         vm.expectEmit(true, false, false, true);
-        emit SellGem(address(this), 100 * ONE_USDX, 100 * WAD, 0);
+        emit SellGem(address(this), 100 * ONE_USDX, 200 * WAD, 0);
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
         assertEq(vat.gem(ILK, address(this)), 0);
         assertEq(vat.dai(address(this)), 0);
-        assertEq(dai.balanceOf(address(this)), 100 ether);
+        assertEq(dai.balanceOf(address(this)), 200 ether);
         assertEq(vat.dai(vow), 0);
         (uint256 inkme, uint256 artme) = vat.urns(ILK, address(this));
         assertEq(inkme, 0);
         assertEq(artme, 0);
         (uint256 inkpsm, uint256 artpsm) = vat.urns(ILK, address(psm));
         assertEq(inkpsm, 100 ether);
-        assertEq(artpsm, 100 ether);
+        assertEq(artpsm, 200 ether);
     }
 
     function testSellGemFee() public {
@@ -185,14 +185,14 @@ contract PsmUnitTest is DSSTest {
 
         gem.approve(address(psm), type(uint256).max);
         vm.expectEmit(true, false, false, true);
-        emit SellGem(address(this), 100 * ONE_USDX, 99 * WAD, int256(WAD));
+        emit SellGem(address(this), 100 * ONE_USDX, 198 * WAD, int256(2 * WAD));
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
         assertEq(vat.gem(ILK, address(this)), 0);
         assertEq(vat.dai(address(this)), 0);
-        assertEq(dai.balanceOf(address(this)), 99 ether);
-        assertEq(vat.dai(vow), RAD);
+        assertEq(dai.balanceOf(address(this)), 198 ether);
+        assertEq(vat.dai(vow), 2 * RAD);
     }
 
     function testSellGemNegativeFee() public {
@@ -207,33 +207,33 @@ contract PsmUnitTest is DSSTest {
 
         gem.approve(address(psm), type(uint256).max);
         vm.expectEmit(true, false, false, true);
-        emit SellGem(address(this), 100 * ONE_USDX, 101 * WAD, -int256(WAD));
+        emit SellGem(address(this), 100 * ONE_USDX, 202 * WAD, -int256(2 * WAD));
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
         assertEq(vat.gem(ILK, address(this)), 0);
         assertEq(vat.dai(address(this)), 0);
-        assertEq(dai.balanceOf(address(this)), 101 ether);
+        assertEq(dai.balanceOf(address(this)), 202 ether);
         assertEq(vat.dai(vow), 0);
-        assertEq(vat.sin(vow), RAD);
+        assertEq(vat.sin(vow), 2 * RAD);
     }
 
     function testSwapBothNoFee() public {
         gem.approve(address(psm), type(uint256).max);
         psm.sellGem(address(this), 100 * ONE_USDX);
-        dai.approve(address(psm), 40 ether);
+        dai.approve(address(psm), 80 ether);
         vm.expectEmit(true, false, false, true);
-        emit BuyGem(address(this), 40 * ONE_USDX, 40 * WAD, 0);
+        emit BuyGem(address(this), 40 * ONE_USDX, 80 * WAD, 0);
         psm.buyGem(address(this), 40 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 940 * ONE_USDX);
         assertEq(vat.gem(ILK, address(this)), 0);
         assertEq(vat.dai(address(this)), 0);
-        assertEq(dai.balanceOf(address(this)), 60 ether);
+        assertEq(dai.balanceOf(address(this)), 120 ether);
         assertEq(vat.dai(vow), 0);
         (uint256 ink, uint256 art) = vat.urns(ILK, address(psm));
         assertEq(ink, 60 ether);
-        assertEq(art, 60 ether);
+        assertEq(art, 120 ether);
     }
 
     function testSwapBothFees() public {
@@ -244,23 +244,23 @@ contract PsmUnitTest is DSSTest {
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
-        assertEq(dai.balanceOf(address(this)), 95 ether);
-        assertEq(vat.dai(vow), 5 * RAD);
+        assertEq(dai.balanceOf(address(this)), 190 ether);
+        assertEq(vat.dai(vow), 10 * RAD);
         (uint256 ink1, uint256 art1) = vat.urns(ILK, address(psm));
         assertEq(ink1, 100 ether);
-        assertEq(art1, 100 ether);
+        assertEq(art1, 200 ether);
 
-        dai.approve(address(psm), 44 ether);
+        dai.approve(address(psm), 88 ether);
         vm.expectEmit(true, false, false, true);
-        emit BuyGem(address(this), 40 * ONE_USDX, 44 * WAD, 4 * int256(WAD));
+        emit BuyGem(address(this), 40 * ONE_USDX, 88 * WAD, int256(8 * WAD));
         psm.buyGem(address(this), 40 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 940 * ONE_USDX);
-        assertEq(dai.balanceOf(address(this)), 51 ether);
-        assertEq(vat.dai(vow),  9 * RAD);
+        assertEq(dai.balanceOf(address(this)), 102 ether);
+        assertEq(vat.dai(vow), 18 * RAD);
         (uint256 ink2, uint256 art2) = vat.urns(ILK, address(psm));
         assertEq(ink2, 60 ether);
-        assertEq(art2, 60 ether);
+        assertEq(art2, 120 ether);
     }
 
     function testSwapBothNegativeFees() public {
@@ -272,24 +272,24 @@ contract PsmUnitTest is DSSTest {
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
-        assertEq(dai.balanceOf(address(this)), 105 ether);
+        assertEq(dai.balanceOf(address(this)), 210 ether);
         assertEq(vat.dai(vow), 0);
-        assertEq(vat.sin(vow), 5 * RAD);
+        assertEq(vat.sin(vow), 10 * RAD);
         (uint256 ink1, uint256 art1) = vat.urns(ILK, address(psm));
         assertEq(ink1, 100 ether);
-        assertEq(art1, 100 ether);
+        assertEq(art1, 200 ether);
 
         vm.expectEmit(true, false, false, true);
-        emit BuyGem(address(this), 40 * ONE_USDX, 36 * WAD, -4 * int256(WAD));
+        emit BuyGem(address(this), 40 * ONE_USDX, 72 * WAD, -int256(8 * WAD));
         psm.buyGem(address(this), 40 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 940 * ONE_USDX);
-        assertEq(dai.balanceOf(address(this)), 69 ether);
+        assertEq(dai.balanceOf(address(this)), 138 ether);
         assertEq(vat.dai(vow), 0);
-        assertEq(vat.sin(vow), 9 * RAD);
+        assertEq(vat.sin(vow), 18 * RAD);
         (uint256 ink2, uint256 art2) = vat.urns(ILK, address(psm));
         assertEq(ink2, 60 ether);
-        assertEq(art2, 60 ether);
+        assertEq(art2, 120 ether);
     }
 
     function testSwapBothOther() public {
@@ -297,11 +297,11 @@ contract PsmUnitTest is DSSTest {
         psm.sellGem(address(this), 100 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
-        assertEq(dai.balanceOf(address(this)), 100 ether);
+        assertEq(dai.balanceOf(address(this)), 200 ether);
         assertEq(vat.dai(vow), 0);
 
         User someUser = new User(psm);
-        dai.mint(address(someUser), 45 ether);
+        dai.mint(address(someUser), 90 ether);
         someUser.buyGem(40 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(this)), 900 * ONE_USDX);
@@ -310,12 +310,12 @@ contract PsmUnitTest is DSSTest {
         assertEq(vat.gem(ILK, address(someUser)), 0 ether);
         assertEq(vat.dai(address(this)), 0);
         assertEq(vat.dai(address(someUser)), 0);
-        assertEq(dai.balanceOf(address(this)), 100 ether);
-        assertEq(dai.balanceOf(address(someUser)), 5 ether);
+        assertEq(dai.balanceOf(address(this)), 200 ether);
+        assertEq(dai.balanceOf(address(someUser)), 10 ether);
         assertEq(vat.dai(vow), 0);
         (uint256 ink, uint256 art) = vat.urns(ILK, address(psm));
         assertEq(ink, 60 ether);
-        assertEq(art, 60 ether);
+        assertEq(art, 120 ether);
     }
 
     function testSwapBothOtherSmallFee() public {
@@ -326,20 +326,20 @@ contract PsmUnitTest is DSSTest {
         user1.sellGem(40 * ONE_USDX);
 
         assertEq(gem.balanceOf(address(user1)), 0 * ONE_USDX);
-        assertEq(dai.balanceOf(address(user1)), 40 ether - 40);
-        assertEq(vat.dai(vow), 40 * RAY);
+        assertEq(dai.balanceOf(address(user1)), 80 ether - 80);
+        assertEq(vat.dai(vow), 80 * RAY);
         (uint256 ink1, uint256 art1) = vat.urns(ILK, address(psm));
         assertEq(ink1, 40 ether);
-        assertEq(art1, 40 ether);
+        assertEq(art1, 80 ether);
 
         user1.buyGem(40 * ONE_USDX - 1);
 
         assertEq(gem.balanceOf(address(user1)), 40 * ONE_USDX - 1);
-        assertEq(dai.balanceOf(address(user1)), 999999999960);
-        assertEq(vat.dai(vow), 40 * RAY);
+        assertEq(dai.balanceOf(address(user1)), 1999999999920);
+        assertEq(vat.dai(vow), 80 * RAY);
         (uint256 ink2, uint256 art2) = vat.urns(ILK, address(psm));
         assertEq(ink2, 1 * 10 ** 12);
-        assertEq(art2, 1 * 10 ** 12);
+        assertEq(art2, 2 * 10 ** 12);
     }
 
     function testSellGemInsufficientGem() public {

--- a/src/tests/mocks/SpotterMock.sol
+++ b/src/tests/mocks/SpotterMock.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+contract SpotterMock {
+    mapping (bytes32 => address) private _ilks;
+    function setPip(bytes32 ilk, address pip) external {
+        _ilks[ilk] = pip;
+    }
+    function ilks(bytes32 ilk) external view returns (address, uint256) {
+        return (_ilks[ilk], 10 ** 27);
+    }
+}

--- a/src/tests/mocks/VatMock.sol
+++ b/src/tests/mocks/VatMock.sol
@@ -6,6 +6,7 @@ contract VatMock {
     uint256 public live = 1;
     uint256 public Line;
     uint256 public debt;
+    uint256 public Art;
 
     struct Urn {
         uint256 ink;   // Locked Collateral  [wad]
@@ -83,6 +84,7 @@ contract VatMock {
 
         gem[i][v] = sub(gem[i][v], dink);
         dai[w]    = add(dai[w],    dtab);
+        Art       = add(Art,       dtab);
 
         urns[i][u] = urn;
 
@@ -112,5 +114,9 @@ contract VatMock {
         dai[v] = add(dai[v], rad);
         sin[u] = add(sin[u], rad);
         debt += rad;
+    }
+
+    function ilks(bytes32) external view returns (uint256, uint256, uint256, uint256, uint256) {
+        return (Art, 0, 0, Line, 0);
     }
 }


### PR DESCRIPTION
Building this in anticipation of things like Backed Finance (passed greenlight), but also Endgame plan stuff (Synthetic ETH). It's very very likely going to be needed at some point.

Will allow collateral that is not stablecoins. Also takes care of moving surplus/deficits to/from the surplus buffer. I've also included a `buff` to allow for some buffer space for interest to collect and move to the surplus buffer.

Considerations:

 * Oracle attack scenarios - should have limits on the damage that can be done. Be aware of every place that sucks from the `vow`.